### PR TITLE
Feature/#99

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -64,10 +64,37 @@
             <h4 class="modal-title">The year is up, here's how you did...</h4>
           </div>
           <div class="modal-body">
-            <h5>Total cases</h5>
-            <p id='win-total-cases'></p>
-            <h5>Total costs</h5>
-            <p id='win-total-costs'></p>
+
+            <!-- Results for the current game-->
+            <div class="d-flex justify-content-center">
+              <div width="300px" class="alert alert-secondary">
+                <h5>This game:</h5>
+                <div>
+                  <p><span class="font-weight-bold">Total cases: </span><span id="win-total-cases"></span></p>
+                  <p><span class="font-weight-bold">Total cost: </span><span id="win-total-costs"></span></p>
+                </div>
+              </div>
+            </div>
+            <br />
+            <!-- Results for up to the last three games -->
+            <div id="prev-games-container" class="d-none">
+              <h5>You previous games:</h5>
+              <table class="table table-condensed">
+                <tbody>
+                  <tr id="past-cases-row">
+                    <td class="font-weight-bold">Total cases</td>
+                  </tr>
+                  <tr id="past-cost-row">
+                    <td class="font-weight-bold">Total cost</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="d-flex justify-content-between align-items-center"></div>
+            </div>
+            <!-- First game message-->
+            <div id="first-game-message" class="d-none font-weight-bold">
+              If you play again you will be able to compare your score with up to three previous games.
+            </div>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-primary" id="restart-btn">Play again</button>

--- a/public/index.html
+++ b/public/index.html
@@ -91,50 +91,54 @@
           </button>
         </div>
         <div class="modal-body">
-        <p>
-          Welcome, you will be responsible for coordinating the response to the Covid-19 pandemic over the next twelve months.
-        </p>
-        <p>
-          Your goal is to minimize the loss of life and the economic impacts
-        </p>
-        <hr>
-        <h5>How to play</h5>
-        <br>
-        <strong>Interacting with the simulation</strong>
-        <p>
-          Please choose your course of action in the <strong>Actions</strong> panel
-          <br>Businesses <button class='player-action-demo m-2 btn btn-sm'>Open</button>
-          <br>Masks <button class='player-action-demo m-2 btn btn-sm'>Optional</button>
-        </p>
-        <strong>Viewing policy consequences</strong>
-        <p>
-          Click 
-          <button class='btn btn-sm btn-light' style='color: red;'>
-            Advance 
-            <svg width="25px" height="25px" viewBox="0 0 16 16" class="bi bi-caret-right-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                <path d="M12.14 8.753l-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
-            </svg>
-          </button>
-          to go forwards in time and see the consequences
-        </p>
-        <p>
-          Click 
-          <button class='btn btn-sm btn-light' style='color: red;'>
-            Undo 
-            <svg width="25px" height="25px" viewBox="0 0 16 16" class="bi bi-caret-left-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                <path d="M3.86 8.753l5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z"/>
-            </svg>
-          </button>
-          to go backwards in time and change your actions
-        </p>
-        <div>
-          
-        </div>
-          
+          <p>
+            Welcome, you will be responsible for coordinating the response to the Covid-19 pandemic over the next twelve
+            months.
+          </p>
+          <p>
+            Your goal is to minimize the loss of life and the economic impacts
+          </p>
+          <hr>
+          <h5>How to play</h5>
+          <br>
+          <strong>Interacting with the simulation</strong>
+          <p>
+            Please choose your course of action in the <strong>Actions</strong> panel
+            <br>Businesses <button class='player-action-demo m-2 btn btn-sm'>Open</button>
+            <br>Masks <button class='player-action-demo m-2 btn btn-sm'>Optional</button>
+          </p>
+          <strong>Viewing policy consequences</strong>
+          <p>
+            Click
+            <button class='btn btn-sm btn-light' style='color: red;'>
+              Advance<br />
+              <svg width="25px" height="25px" viewBox="0 0 16 16" class="bi bi-caret-right-fill" fill="currentColor"
+                xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M12.14 8.753l-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z" />
+              </svg>
+            </button>
+            to go forwards in time and see the consequences
+          </p>
+          <p>
+            Click
+            <button class='btn btn-sm btn-light' style='color: red;'>
+              Undo<br />
+              <svg width="25px" height="25px" viewBox="0 0 16 16" class="bi bi-caret-left-fill" fill="currentColor"
+                xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M3.86 8.753l5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z" />
+              </svg>
+            </button>
+            to go backwards in time and change your actions
+          </p>
+          <div>
+
+          </div>
+
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary">Save changes</button>
-          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
         </div>
       </div>
     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -57,14 +57,11 @@
     </div>
 
     <!-- Win screen modal -->
-    <div class="modal" tabindex="-1" id='win-screen'>
+    <div class="modal" tabindex="-1" id='win-screen' data-backdrop="static" data-keyboard="false">
       <div class="modal-dialog">
         <div class="modal-content">
           <div class="modal-header">
             <h4 class="modal-title">The year is up, here's how you did...</h4>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
           </div>
           <div class="modal-body">
             <h5>Total cases</h5>
@@ -73,7 +70,7 @@
             <p id='win-total-costs'></p>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-primary" id="restart-btn">Reset</button>
+            <button type="button" class="btn btn-primary" id="restart-btn">Play again</button>
           </div>
         </div>
       </div>
@@ -81,14 +78,11 @@
   </div>
 
   <!-- Introduction modal -->
-  <div class="modal" tabindex="-1" role="dialog" id='welcome-screen'>
+  <div class="modal" tabindex="-1" role="dialog" id='welcome-screen' data-backdrop="static" data-keyboard="false">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title">Welcome</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
         </div>
         <div class="modal-body">
           <p>
@@ -137,8 +131,9 @@
           </div>
 
         </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+        <div class="modal-footer justify-content-between align-items-center">
+          <div><input type="checkbox" id="hide-welcome"><label for="hide-welcome">Do not show again</label></div>
+          <div><button type="button" class="btn btn-primary" data-dismiss="modal">Close</button></div>
         </div>
       </div>
     </div>

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -7,6 +7,7 @@ import { setControlsToTurn, showWinScreen, updateIndicators } from './setGameUI'
 import { months } from '../lib/util';
 import { Simulator } from '../simulator/Simulator';
 import { GameHistory } from './GameHistory';
+import { GameOptions, GameOptionsStore } from './GameOptions';
 
 interface CurrentUISelection {
     transport: boolean;
@@ -25,11 +26,13 @@ export class GameEngine {
     private simulator: Simulator;
     private currentlySelectedActions: CurrentUISelection;
     private gameHistory: GameHistory;
+    private gameOptions: GameOptionsStore;
 
     constructor(scenario: Scenario) {
         this.scenario = scenario;
         this.simulator = new Simulator(scenario);
         this.gameHistory = new GameHistory();
+        this.gameOptions = new GameOptionsStore();
 
         this.currentlySelectedActions = {
             transport: false,
@@ -42,6 +45,10 @@ export class GameEngine {
     start() {
         const onPlayerSelectsAction = (action: AvailableActions) => {
             this.currentlySelectedActions[action] = !this.currentlySelectedActions[action];
+        };
+
+        const toggleWelcomeScreen = (showWelcomeScreenAtStart: boolean) => {
+            this.gameOptions.setGameOptions({ showWelcomeScreenAtStart });
         };
 
         const onEndTurn = () => {
@@ -59,7 +66,15 @@ export class GameEngine {
             this.onPlayAgain();
         };
 
-        createGameUI(this.scenario.initialContainmentPolicies, onPlayerSelectsAction, onEndTurn, onUndo, onPlayAgain);
+        createGameUI(
+            this.gameOptions.getGameOptions(),
+            this.scenario.initialContainmentPolicies,
+            toggleWelcomeScreen,
+            onPlayerSelectsAction,
+            onEndTurn,
+            onUndo,
+            onPlayAgain
+        );
         setControlsToTurn(0, this.currentlySelectedActions, [], this.scenario.initialContainmentPolicies);
         const history = this.simulator.history(); // In the first turn total history is the last month history
         updateIndicators(0, history, history, this.scenario.hospitalCapacity);

--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -154,7 +154,15 @@ export class GameEngine {
         const totalCases = history.reduce(totalCasesReducer, 0);
         const totalCostReducer = (acc: number, it: Indicators) => acc + it.totalCost;
         const totalCost = history.reduce(totalCostReducer, 0);
-        showWinScreen(totalCost, totalCases);
+
+        const prevGames = this.gameHistory.getPreviousGames().map((it) => {
+            return {
+                totalCases: it.history.reduce(totalCasesReducer, 0),
+                totalCost: it.history.reduce(totalCostReducer, 0)
+            };
+        });
+
+        showWinScreen(totalCost, totalCases, prevGames);
     }
 
     /**

--- a/src/game/GameHistory.ts
+++ b/src/game/GameHistory.ts
@@ -1,0 +1,41 @@
+import { Simulator } from '@src/simulator/Simulator';
+import { SimulatorState } from '@src/simulator/SimulatorState';
+
+/**
+ * This class acts as a repository of past games enabling comparisons across playthroughs.
+ * If behaves as a FIFO queue of games with a user defined limit.
+ */
+export class GameHistory {
+    private maxHistorySize: number;
+    private storageEngine: Storage;
+    private historyKey: string;
+
+    constructor(maxHistorySize = 3) {
+        this.maxHistorySize = maxHistorySize;
+        this.historyKey = 'gameHistory';
+        this.storageEngine = window.sessionStorage;
+        if (this.storageIsEmpty()) {
+            this.storageEngine.setItem(this.historyKey, '[]'); // init with an empty array
+        }
+    }
+
+    saveGame(gameState: SimulatorState) {
+        const parsedItems = this.getPreviousGames();
+
+        if (parsedItems.length === this.maxHistorySize) {
+            parsedItems.splice(0, 1); // Behaves like a fifo-queue
+        }
+
+        parsedItems.push(gameState);
+        this.storageEngine.setItem(this.historyKey, JSON.stringify(parsedItems));
+    }
+
+    getPreviousGames(): SimulatorState[] {
+        const rawItems = this.storageEngine.getItem(this.historyKey);
+        return JSON.parse(rawItems) as SimulatorState[];
+    }
+
+    private storageIsEmpty(): boolean {
+        return this.storageEngine.getItem(this.historyKey) === null;
+    }
+}

--- a/src/game/GameOptions.ts
+++ b/src/game/GameOptions.ts
@@ -1,0 +1,28 @@
+export interface GameOptions {
+    welcomeScreenVisibility: boolean;
+}
+
+const defaultGameOptions = { welcomeScreenVisibility: false };
+
+export class GameOptionsStore {
+    private optionStore: Storage;
+    private gameOptionKey: string;
+
+    constructor() {
+        this.optionStore = window.sessionStorage;
+        this.gameOptionKey = 'gameOptions';
+    }
+
+    setGameOptions(gameOptions: GameOptions) {
+        this.optionStore.setItem(this.gameOptionKey, JSON.stringify(gameOptions));
+    }
+
+    getGameOptions(): GameOptions {
+        const rawGameOptions = this.optionStore.getItem(this.gameOptionKey);
+        if (rawGameOptions === null) {
+            return defaultGameOptions;
+        } else {
+            return JSON.parse(rawGameOptions) as GameOptions;
+        }
+    }
+}

--- a/src/game/GameOptions.ts
+++ b/src/game/GameOptions.ts
@@ -1,8 +1,8 @@
 export interface GameOptions {
-    welcomeScreenVisibility: boolean;
+    showWelcomeScreenAtStart: boolean;
 }
 
-const defaultGameOptions = { welcomeScreenVisibility: false };
+const defaultGameOptions = { showWelcomeScreenAtStart: true };
 
 export class GameOptionsStore {
     private optionStore: Storage;

--- a/src/game/LineChart.ts
+++ b/src/game/LineChart.ts
@@ -1,104 +1,115 @@
 import * as Highcharts from 'highcharts';
 import { nFormatter } from '../lib/util';
 
-export const buildCasesChart = (containerId: string, caseSeries: any[], totalCostSeries: any[], hospitalCapacity:Number) => {
-    return Highcharts.chart(containerId, {
-        chart: {
-            type: 'line'
-        },
-        title: {
-            text: ''
-        },
-        credits: {
-            enabled: false
-        },
-        legend: {
-            enabled: false
-        },
-        xAxis: {
-            lineWidth: 0,
-            minorGridLineWidth: 0,
-            labels: {
+export const buildCasesChart = (
+    containerId: string,
+    caseSeries: any[],
+    totalCostSeries: any[],
+    hospitalCapacity: number
+) => {
+    return Highcharts.chart(
+        containerId,
+        {
+            chart: {
+                type: 'line'
+            },
+            title: {
+                text: ''
+            },
+            credits: {
                 enabled: false
             },
-            minorTickLength: 0,
-            tickLength: 0
-        },
-        yAxis: [
-            {
-                title: {
-                    text: 'Cases/day',
-                    style: {
-                        color: 'blue',
-						fontSize: '16px'
-                    }
-                },
+            legend: {
+                enabled: false
+            },
+            xAxis: {
+                lineWidth: 0,
+                minorGridLineWidth: 0,
                 labels: {
-                    style: {
-                        color: 'blue',
-						fontSize: '16px'
-                    }
+                    enabled: false
                 },
-                min: 0,
-				plotLines: [{
-					value: hospitalCapacity,
-					color: '#C00000',
-					dashStyle: 'shortdash',
-					width: 1,
-					label: {
-						text: 'hospital capacity'
-					}
-				}],
+                minorTickLength: 0,
+                tickLength: 0
             },
-            {
-                title: {
-                    text: 'USD',
-                    style: {
-                        color: 'red',
-						fontSize: '16px'
-                    }
+            yAxis: [
+                {
+                    title: {
+                        text: 'Cases/day',
+                        style: {
+                            color: 'blue',
+                            fontSize: '16px'
+                        }
+                    },
+                    labels: {
+                        style: {
+                            color: 'blue',
+                            fontSize: '16px'
+                        }
+                    },
+                    min: 0,
+                    plotLines: [
+                        {
+                            value: hospitalCapacity,
+                            color: '#C00000',
+                            dashStyle: 'ShortDash',
+                            width: 1,
+                            label: {
+                                text: 'hospital capacity'
+                            }
+                        }
+                    ]
                 },
-                labels: {
-                    style: {
-                        color: 'red',
-						fontSize: '16px'
-                    }
+                {
+                    title: {
+                        text: 'USD',
+                        style: {
+                            color: 'red',
+                            fontSize: '16px'
+                        }
+                    },
+                    labels: {
+                        style: {
+                            color: 'red',
+                            fontSize: '16px'
+                        }
+                    },
+                    min: 0,
+                    opposite: true
+                }
+            ],
+            tooltip: {
+                formatter: function () {
+                    const date = (this.x as any).toLocaleDateString('en-US', {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric'
+                    });
+                    console.log(date);
+                    return this.points.reduce(function (prev, point) {
+                        return `${prev}<br/> ${point.series.name}: ${nFormatter(point.y, 1)}`;
+                    }, `<b>${date}<br/>`);
                 },
-                min: 0,
-                opposite: true
-            }
-        ],
-        tooltip: {
-            formatter: function () {
-                const date = (this.x as any).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'short',
-                    day: 'numeric'
-                });
-                console.log(date);
-                return this.points.reduce(function (prev, point) {
-                    return `${prev}<br/> ${point.series.name}: ${nFormatter(point.y, 1)}`;
-                }, `<b>${date}<br/>`);
+                shared: true
             },
-            shared: true
+            series: [
+                {
+                    type: 'line',
+                    name: 'Cases/day',
+                    data: caseSeries,
+                    yAxis: 0,
+                    color: 'blue'
+                },
+                {
+                    type: 'line',
+                    name: 'Costs',
+                    data: totalCostSeries,
+                    yAxis: 1,
+                    color: 'red'
+                }
+            ]
         },
-        series: [
-            {
-                type: 'line',
-                name: 'Cases/day',
-                data: caseSeries,
-                yAxis: 0,
-                color: 'blue'
-            },
-            {
-                type: 'line',
-                name: 'Costs',
-                data: totalCostSeries,
-                yAxis: 1,
-                color: 'red'
-            }
-        ]
-    });
+        () => {}
+    );
 };
 
 export const updateCasesChart = (casesChart: any, caseSeries: any[], totalCostSeries: any[]) => {

--- a/src/game/createGameUI.js
+++ b/src/game/createGameUI.js
@@ -40,7 +40,6 @@ export const createGameUI = (
     onRestart,
     numberOfColumns = 12
 ) => {
-
     // Show welcome screen
     $('#welcome-screen').modal('show');
 
@@ -117,38 +116,38 @@ export const createGameUI = (
             }
         }
     });
-    
+
     const footerRow = createEle('tr', tableFooter);
 
     for (let i = 0; i < numberOfColumns + 1; i += 1) {
         const id = i > 0 ? `month-btns-${i}` : undefined;
         const footerCell = createEle('td', footerRow, id);
-            footerCell.style.textAlign = 'center';
-        const btnGrp = createEle('DIV', footerCell)
-            btnGrp.className = 'btn-group';
-            btnGrp.role = 'group';
-        
-        if (!(i === 0)) { 
-            let btn = createEle('button', btnGrp, `endTurn-btn-${i}`);
+        footerCell.style.textAlign = 'center';
+        const btnGrp = createEle('DIV', footerCell);
+        btnGrp.className = 'btn-group';
+        btnGrp.role = 'group';
+
+        if (!(i === 0)) {
+            const btn = createEle('button', btnGrp, `endTurn-btn-${i}`);
             btn.className = `btn btn-sm btn-light turn-btn-grp`;
             btn.style.width = '80px'; // '100%';
             btn.name = 'Go forwards in time';
             btn.type = 'button';
             btn.innerHTML = `
-                Advance 
+                Advance<br/>
                 <svg width="25px" height="25px" viewBox="0 0 16 16" class="bi bi-caret-right-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                     <path d="M12.14 8.753l-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
                 </svg>
             `;
             btn.onclick = onEndTurn; // END TURN EVENT (in game-engine.ts)
         } else {
-            let btn = createEle('button', btnGrp, `undo-btn`);
+            const btn = createEle('button', btnGrp, `undo-btn`);
             btn.className = `btn btn-sm btn-light undo-btn-grp`;
             btn.style.width = '80px'; // '100%';
             btn.name = 'Go backwards in time';
             btn.type = 'button';
             btn.innerHTML = `
-                Undo 
+                Undo<br/>
                 <svg width="25px" height="25px" viewBox="0 0 16 16" class="bi bi-caret-left-fill" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                     <path d="M3.86 8.753l5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z"/>
                 </svg>
@@ -156,7 +155,7 @@ export const createGameUI = (
             btn.onclick = onUndo; // UNDO EVENT (in game-engine.ts)
         }
     }
-    
+
     // Add extra event handlers
     $(`#restart-btn`).on('click', () => {
         onRestart();

--- a/src/game/createGameUI.js
+++ b/src/game/createGameUI.js
@@ -139,7 +139,7 @@ export const createGameUI = (
                     <path d="M12.14 8.753l-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
                 </svg>
             `;
-            btn.onclick = onEndTurn; // END TURN EVENT (in game-engine.ts)
+            btn.onclick = onEndTurn; // END TURN EVENT (in GameEngine.ts)
         } else {
             const btn = createEle('button', btnGrp, `undo-btn`);
             btn.className = `btn btn-sm btn-light undo-btn-grp`;
@@ -152,7 +152,7 @@ export const createGameUI = (
                     <path d="M3.86 8.753l5.482 4.796c.646.566 1.658.106 1.658-.753V3.204a1 1 0 0 0-1.659-.753l-5.48 4.796a1 1 0 0 0 0 1.506z"/>
                 </svg>
             `;
-            btn.onclick = onUndo; // UNDO EVENT (in game-engine.ts)
+            btn.onclick = onUndo; // UNDO EVENT (in GameEngine.ts)
         }
     }
 

--- a/src/game/createGameUI.js
+++ b/src/game/createGameUI.js
@@ -33,15 +33,24 @@ Elements created by this method accessed by their IDs
 
 */
 export const createGameUI = (
+    gameOptions,
     listOfPlayerActions,
+    showWelcomeScreenAtStart,
     onPlayerSelectsAction,
     onEndTurn,
     onUndo,
     onRestart,
     numberOfColumns = 12
 ) => {
-    // Show welcome screen
-    $('#welcome-screen').modal('show');
+    // Show welcome screen if the options allow for it
+    if (gameOptions.showWelcomeScreenAtStart) {
+        $('#hide-welcome').on('click', (e) => {
+            const isChecked = $(e.target).is(':checked');
+            showWelcomeScreenAtStart(!isChecked);
+        });
+
+        $('#welcome-screen').modal('show');
+    }
 
     const tableRoot = $(`#player-actions-container`)[0];
 

--- a/src/game/createGameUI.js
+++ b/src/game/createGameUI.js
@@ -44,11 +44,6 @@ export const createGameUI = (
 ) => {
     // Show welcome screen if the options allow for it
     if (gameOptions.showWelcomeScreenAtStart) {
-        $('#hide-welcome').on('click', (e) => {
-            const isChecked = $(e.target).is(':checked');
-            showWelcomeScreenAtStart(!isChecked);
-        });
-
         $('#welcome-screen').modal('show');
     }
 
@@ -167,6 +162,8 @@ export const createGameUI = (
 
     // Add extra event handlers
     $(`#restart-btn`).on('click', () => {
+        const isChecked = $('#hide-welcome').is(':checked');
+        showWelcomeScreenAtStart(!isChecked);
         onRestart();
     });
 };

--- a/src/game/game-engine.ts
+++ b/src/game/game-engine.ts
@@ -54,10 +54,9 @@ export class GameEngine {
         };
 
         createGameUI(this.scenario.initialContainmentPolicies, onPlayerSelectsAction, onEndTurn, onUndo, onRestart);
-        setControlsToTurn(0, this.currentlySelectedActions, '', this.scenario.initialContainmentPolicies); // REMOVED welcome event - was [WelcomeEvent]
+        setControlsToTurn(0, this.currentlySelectedActions, [], this.scenario.initialContainmentPolicies);
         const history = this.simulator.history(); // In the first turn total history is the last month history
-        updateIndicators(0, history, history, this.simulator.scenario.hospitalCapacity);
-        
+        updateIndicators(0, history, history, this.scenario.hospitalCapacity);
     }
 
     private undoLastTurn() {
@@ -91,7 +90,7 @@ export class GameEngine {
                 this.scenario.initialContainmentPolicies
             );
             const lastTurnHistory = updatedTurn > 0 ? simulatorState.timeline[updatedTurn - 1].history : [];
-            updateIndicators(updatedTurn, simulatorState.history, lastTurnHistory,this.simulator.scenario.hospitalCapacity);
+            updateIndicators(updatedTurn, simulatorState.history, lastTurnHistory, this.scenario.hospitalCapacity);
         }
     }
 
@@ -106,10 +105,10 @@ export class GameEngine {
                 nextTurn.newInGameEvents,
                 this.scenario.initialContainmentPolicies
             );
-            updateIndicators(currentTurn, history, nextTurn.lastTurnIndicators,this.simulator.scenario.hospitalCapacity);
+            updateIndicators(currentTurn, history, nextTurn.lastTurnIndicators, this.scenario.hospitalCapacity);
         } else {
             // Do the final graph update
-            updateIndicators(currentTurn, history, nextTurn.lastTurnIndicators,this.simulator.scenario.hospitalCapacity);
+            updateIndicators(currentTurn, history, nextTurn.lastTurnIndicators, this.scenario.hospitalCapacity);
 
             // Show the win screen
             const totalCasesReducer = (acc: number, it: Indicators) => acc + it.numInfected;

--- a/src/game/setGameUI.js
+++ b/src/game/setGameUI.js
@@ -16,7 +16,7 @@ import { buildCasesChart, updateCasesChart } from './LineChart.ts';
 // Object that will keep track of the chart instance
 let casesChart;
 
-function updateCumulativeIndicators(fullHistory) {
+const updateCumulativeIndicators = (fullHistory) => {
     if (fullHistory.length === 0) {
         console.warn('History should not be empty. Indicators will not be renderer correctly');
     } else {
@@ -33,7 +33,7 @@ function updateCumulativeIndicators(fullHistory) {
         $(`#deaths-total`).html(nFormatter(totaldeaths - fullHistory[0].numDead, 0));
         $(`#cost-total`).html(`$ ${nFormatter(totalcosts - fullHistory[0].totalCost, 1)}`);
     }
-}
+};
 
 const updateGraphs = (history, hospitalCapacity) => {
     const fullYear = 365;
@@ -90,10 +90,23 @@ export const updateIndicators = (turnNumber, fullHistory, lastTurnHistory, hospi
     updateMonthlyIndicators(turnNumber, lastTurnHistory);
 };
 
-export const showWinScreen = (totalCost, totalCases) => {
+export const showWinScreen = (totalCost, totalCases, prevGames) => {
     $(`#win-total-cases`).html(nFormatter(totalCases, 1));
     $(`#win-total-costs`).html(`$ ${nFormatter(totalCost, 1)}`);
     $('#win-screen').modal('show');
+
+    const prevGamesContainer = $('#prev-games-container');
+    if (prevGames.length > 0) {
+        prevGamesContainer.removeClass('d-none');
+        const costRow = $('#past-cost-row');
+        const casesRow = $('#past-cases-row');
+        prevGames.forEach((pastGame) => {
+            casesRow.append(`<td>${nFormatter(pastGame.totalCases, 1)}</td>`);
+            costRow.append(`<td>$ ${nFormatter(pastGame.totalCost, 1)}</td>`);
+        });
+    } else {
+        $('#first-game-message').removeClass('d-none');
+    }
 };
 
 // Hide and disable all buttons

--- a/src/game/setGameUI.js
+++ b/src/game/setGameUI.js
@@ -142,8 +142,8 @@ export const setControlsToTurn = (playerTurn, dictOfActivePolicies, inGameEvents
 
     // Style current action buttons
     $('.turn-btn-grp').hide();
-    $(`#undo-btn-${playerTurn+1}`).show();
-    $(`#endTurn-btn-${playerTurn+1}`).show();
+    $(`#undo-btn-${playerTurn + 1}`).show();
+    $(`#endTurn-btn-${playerTurn + 1}`).show();
 
     // Remove styles from future choices
     $(`[id^="turn${playerTurn + 1}-"]`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { GameEngine } from './game/game-engine';
+import { GameEngine } from './game/GameEngine';
 import { US } from './simulator/scenarios/US';
 import * as $ from 'jquery';
 import 'bootstrap/js/dist/modal';

--- a/src/lib/Probabilities.ts
+++ b/src/lib/Probabilities.ts
@@ -10,6 +10,14 @@ export class FakeNegativeBinomial {
         this.variance = (p * r) / ((1 - p) * (1 - p));
     }
 
+    getMean() {
+        return this.mean;
+    }
+
+    getVariance() {
+        return this.variance;
+    }
+
     sample() {
         return Math.max(0, Math.floor(jStat.normal.sample(this.mean, this.variance ** 0.5)));
     }

--- a/src/simulator/Simulator.ts
+++ b/src/simulator/Simulator.ts
@@ -264,20 +264,22 @@ export class Simulator {
         const r_single_chain = 0.17; // 50.0;
         const lam_single_chain = 1.0 * action_r;
         const p_single_chain = lam_single_chain / (r_single_chain + lam_single_chain);
-        
+
         const single_chain_distr = new FakeNegativeBinomial(r_single_chain, p_single_chain);
-        const new_num_infected_mean = single_chain_distr.mean * lam;
-        const new_num_infected_variance = single_chain_distr.variance * lam;
-        
-        const new_num_infected = Math.max(0, Math.floor(jStat.normal.sample(new_num_infected_mean, new_num_infected_variance ** 0.5)));
-        
+        const new_num_infected_mean = single_chain_distr.getMean() * lam;
+        const new_num_infected_variance = single_chain_distr.getVariance() * lam;
+
+        const new_num_infected = Math.max(
+            0,
+            Math.floor(jStat.normal.sample(new_num_infected_mean, new_num_infected_variance ** 0.5))
+        );
+
         return new_num_infected + this.currentTurn.indicators.importedCasesPerDay; // remove stochasticity; was: return new_num_infected;
     }
 
     private generateNewCases(numInfected: number, r: number) {
         const fractionSusceptible = 1; // immune population?
-        const expectedNewCases =
-            numInfected * r * fractionSusceptible; // + this.currentTurn.indicators.importedCasesPerDay;
+        const expectedNewCases = numInfected * r * fractionSusceptible; // + this.currentTurn.indicators.importedCasesPerDay;
         return expectedNewCases;
     }
 


### PR DESCRIPTION
Closes #99 

Displays the previous scores of up to 3 previous games in the win screen:

![image](https://user-images.githubusercontent.com/803668/101993008-ee9a5580-3cae-11eb-8f13-49145f6734f3.png)

This uses the browser's `SessionStorage` so the history gets wiped out if the user closes the tab. I think that's okay, but we could also use `LocalStorage` instead, that can keep the data across sessions (however it's not as easy to revert to an initial state - we would need a button on the UI for that).

Also added the ability to dismiss the welcome screen, it was annoying after a few games:

![image](https://user-images.githubusercontent.com/803668/101993070-8c8e2000-3caf-11eb-9f7d-30931154f5c4.png)

Also corrected the bug related to being able to go back to the game after the win screen has been shown.
